### PR TITLE
Support JWT token authentication + Http basic authentication now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ cython_debug/
 
 # DeployMe
 misc/DeployMe/
+
+# JetBrains Ide
+.idea/

--- a/backend/presentation/Viewsets/author_view.py
+++ b/backend/presentation/Viewsets/author_view.py
@@ -2,7 +2,7 @@ from presentation.models import Author, Inbox
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
 from presentation.Serializers import *
-from rest_framework import viewsets, status
+from rest_framework import viewsets, status, permissions
 from rest_framework.response import Response
 import uuid
 from urllib.parse import urlparse
@@ -23,10 +23,23 @@ POST:
 
 '''
 
+# http://www.tomchristie.com/rest-framework-2-docs/api-guide/permissions
+# https://github.com/encode/django-rest-framework/issues/1067, kot-behemoth commented on 29 Jan 2015
+class IsAuthenticatedOrCreate(permissions.BasePermission):
+    # permission override, to prevent login before registration
+    def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            if view.action == "create":
+                return True
+            else:
+                return False
+        else:
+            return True
 
 class AuthorViewSet(viewsets.ModelViewSet):
     serializer_class = AuthorSerializer
     queryset = Author.objects.all()
+    permission_classes = (IsAuthenticatedOrCreate,)
 
     # GET ://service/author/{AUTHOR_ID}/
     def retrieve(self, request, *args, **kwargs):

--- a/backend/presentation/views.py
+++ b/backend/presentation/views.py
@@ -48,7 +48,7 @@ def get_author_for_user(request):
     except User.DoesNotExist:
         return Response({"msg": "Cannot find corresponding author for " + str(who) + "."}, 200)
     except:
-        return Response({"msg": "Internal Server Error"}, 500)
+        return Response({"msg": "Internal server error."}, 500)
 
 
 class UserList(APIView):

--- a/backend/socialdist/settings.py
+++ b/backend/socialdist/settings.py
@@ -73,7 +73,7 @@ MIDDLEWARE = [
 # }
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.AllowAny',
+        'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',

--- a/frontend/src/components/Friends/index.js
+++ b/frontend/src/components/Friends/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, List, Avatar, message } from "antd";
 import { UserOutlined, UserSwitchOutlined } from "@ant-design/icons";
 import { getFriendList } from "../../requests/requestFriends";
-import { domain, port } from "../../requests/URL";
+// import { domain, port } from "../../requests/URL";
 
 export default class Friends extends React.Component {
   constructor(props) {

--- a/frontend/src/components/InboxRequest/index.js
+++ b/frontend/src/components/InboxRequest/index.js
@@ -1,8 +1,9 @@
 import React from "react";
-import { List, message, Image } from "antd";
+// import { List, message, Image } from "antd";
+import { List, message } from "antd";
 import { getRequest } from "../../requests/requestFriendRequest";
-import ReactMarkdown from "react-markdown";
-import PostDisplay from "../PostDisplay";
+// import ReactMarkdown from "react-markdown";
+// import PostDisplay from "../PostDisplay";
 import { getAuthorByAuthorID } from "../../requests/requestAuthor";
 
 export default class InboxRequest extends React.Component {

--- a/frontend/src/components/Signup/index.js
+++ b/frontend/src/components/Signup/index.js
@@ -16,13 +16,16 @@ export default class Signup extends React.Component {
 
   onFinish = (values) => {
     postAuthor(values).then((response) => {
+      console.log(response.data);
       if (response.status === 200) {
-        message.success("Registration successed: " + response.data.msg);
-        // window.location.reload();
-      } else {
         if (Object.keys(response.data).length === 1) {
-          message.error("Registration failed: " + response.data.msg);
+          message.error("Registration failed: " + response.data.msg);  
+        } else {
+          message.success("Registration successful: " + response.data.msg);
+          // window.location.reload();
         }
+      } else {
+        message.error("Registration failed: " + response.data.msg);
       }
     });
   };
@@ -107,7 +110,7 @@ export default class Signup extends React.Component {
                 type: "url",
                 message: "The input is not valid url!",
               },
-              { required: true, message: "Please input your github link!" },
+              // { required: false, message: "Please input your github link!" },
             ]}
           >
             <Input />

--- a/frontend/src/requests/requestAuthor.js
+++ b/frontend/src/requests/requestAuthor.js
@@ -13,6 +13,7 @@ export function getAuthor(params = {}) {
     .post(URL, requestBody, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -33,6 +34,7 @@ export function getAuthorByUsername(params = {}) {
   .post(URL, requestBody, {
     headers: {
       "Content-Type": "application/json",
+      "Authorization": `JWT ${localStorage.getItem("token")}`,
     }
   })
   .then(response => {
@@ -50,6 +52,7 @@ export function getAuthorByAuthorID(params = {}) {
     .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -95,6 +98,7 @@ export function updateAuthor(params = {}) {
     .put(URL, requestBody, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {

--- a/frontend/src/requests/requestComment.js
+++ b/frontend/src/requests/requestComment.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { domain, port } from "./URL";
+// import { domain, port } from "./URL";
 
 export function getCommentList(params = {}) {
   const URL = `${params.postID.toString()}/comments/`;
@@ -8,6 +8,7 @@ export function getCommentList(params = {}) {
     .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -25,6 +26,7 @@ export function getComment(params = {}) {
     .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -42,6 +44,7 @@ export function postComment(params = {}) {
     .post(URL, params, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {

--- a/frontend/src/requests/requestFriendRequest.js
+++ b/frontend/src/requests/requestFriendRequest.js
@@ -9,6 +9,7 @@ export function postRequest(params = {}) {
     .post(URL, params, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -21,11 +22,11 @@ export function postRequest(params = {}) {
 
 export function getRequest(params = {}) {
   const URL = `${params.authorID.toString()}/inbox-request/`;
-
   return axios
-    .get(URL, params, {
+    .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {

--- a/frontend/src/requests/requestFriends.js
+++ b/frontend/src/requests/requestFriends.js
@@ -7,6 +7,7 @@ export function getFriendList(params = {}) {
     .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {

--- a/frontend/src/requests/requestPost.js
+++ b/frontend/src/requests/requestPost.js
@@ -8,6 +8,7 @@ export function getAllPublicPosts() {
     .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -25,6 +26,7 @@ export function getPostList(params = {}) {
     .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -42,6 +44,7 @@ export function getPost(params = {}) {
     .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -59,6 +62,7 @@ export function sendPost(params = {}) {
     .post(URL, params, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -76,6 +80,7 @@ export function updatePost(params = {}) {
     .put(URL, params, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -93,6 +98,7 @@ export function deletePost(params = {}) {
     .delete(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {
@@ -106,11 +112,11 @@ export function deletePost(params = {}) {
 
 export function getInboxPost(params = {}) {
   const URL = params.authorID.toString() + "/inbox-post/";
-
   return axios
     .get(URL, {
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `JWT ${localStorage.getItem("token")}`,
       },
     })
     .then((response) => {

--- a/misc/Deploy/settings.py
+++ b/misc/Deploy/settings.py
@@ -73,7 +73,7 @@ MIDDLEWARE = [
 # }
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.AllowAny',
+        'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',


### PR DESCRIPTION
1. Server administrator can optionally approve users' registration.
2. Support Http basic authentication now.
3. JWT token authentication still available for our website, and should be priority to use in our website.
4. Currently to add a node means add an user (but not an author).
5. Delete an user = remove an node.
6. Deactivate an user = block node access.
7. It is external website's decision to use JWT authentication, but Http authentication will be supported no matter what.

- [ ] closing #38 
- [ ] closing #40 
- [ ] closing #25 
- [ ] closing #35 
- [ ] closing #32